### PR TITLE
fix: pipeline Promises `any` if the pipeline has a non-function parameter

### DIFF
--- a/.changeset/chatty-teachers-knock.md
+++ b/.changeset/chatty-teachers-knock.md
@@ -1,0 +1,5 @@
+---
+"@apie/pipe": patch
+---
+
+fix: pipeline Promises `any` if the pipeline has a non-function parameter


### PR DESCRIPTION
I'm a little unsure if my `N<P0> | N<P1>| ...` approach is good.

Hopefully it doesn't cause trouble or performance issues😬