### PR TITLE
fix: simplifies return value in pipe

### DIFF
--- a/.changeset/curly-cameras-wait.md
+++ b/.changeset/curly-cameras-wait.md
@@ -1,0 +1,5 @@
+---
+"@apie/utility": patch
+---
+
+fix: interfaces not treated as UnknownRecord's

--- a/.changeset/wet-candles-jog.md
+++ b/.changeset/wet-candles-jog.md
@@ -1,0 +1,5 @@
+---
+"@apie/pipe": patch
+---
+
+fix: simplifies return value in pipe

--- a/packages/pipe/src/pipe.ts
+++ b/packages/pipe/src/pipe.ts
@@ -28,14 +28,14 @@ type ParamReturnResponse<P extends PipeFn | Nil> =
 
 /** Returns the (non-APIResponse) content of the Pipe Parameter Function */
 type PipeOrValue<P = never, R = unknown> =
-	[Nil] extends [R]
-	? P extends PipeFn<infer _, infer _, infer TReturn>
+	[Nil] extends [P]
+	? Exclude<R, APIResponse>
+	: P extends PipeFn<infer _, infer _, infer TReturn>
 	? Exclude<TReturn, APIResponse>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	: P extends PipeFn<any, any, infer TReturn>
 	? Exclude<TReturn, APIResponse>
 	: never
-	: Exclude<R, APIResponse>
 
 interface Options<T extends UnknownRecord> {
 	/** Functions to run before every pipeline */

--- a/packages/pipe/src/pipe.ts
+++ b/packages/pipe/src/pipe.ts
@@ -1,4 +1,4 @@
-import type { MaybePromise, MaybeArray, UnknownRecord, Writable, IsUnknown } from '@apie/utility/types'
+import type { MaybePromise, MaybeArray, UnknownRecord, IsUnknown } from '@apie/utility/types'
 import { type APIResponse } from '@apie/responses/types'
 import { InternalServerError, isResponse } from '@apie/responses'
 
@@ -30,12 +30,12 @@ type ParamReturnResponse<P extends PipeFn | Nil> =
 type PipeOrValue<P = never, R = unknown> =
 	[Nil] extends [R]
 	? P extends PipeFn<infer _, infer _, infer TReturn>
-	? Writable<Exclude<TReturn, APIResponse>>
+	? Exclude<TReturn, APIResponse>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	: P extends PipeFn<any, any, infer TReturn>
-	? Writable<Exclude<TReturn, APIResponse>>
+	? Exclude<TReturn, APIResponse>
 	: never
-	: Writable<Exclude<R, APIResponse>>
+	: Exclude<R, APIResponse>
 
 interface Options<T extends UnknownRecord> {
 	/** Functions to run before every pipeline */

--- a/packages/utility/src/types/unknownrecord.ts
+++ b/packages/utility/src/types/unknownrecord.ts
@@ -1,1 +1,2 @@
-export type UnknownRecord = Record<string | number | symbol, unknown>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type UnknownRecord = Record<PropertyKey, any>


### PR DESCRIPTION
### Also

"@apie/utility": patch
fix: interfaces not treated as UnknownRecord's