### PR TITLE
feat: pipe exit early

### DIFF
--- a/.changeset/itchy-boats-drum.md
+++ b/.changeset/itchy-boats-drum.md
@@ -1,0 +1,5 @@
+---
+"@apie/pipe": minor
+---
+
+feat: exit early in a pipe with `return exit(value?)`

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"apps/*"
 	],
 	"scripts": {
-		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*'",
+		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*' --ignore-pattern '~generated-type.ts'",
 		"precommit": "bun *:package && bun lint && bun *:typecheck && bun *:test",
 		"*:typecheck": "pnpm --stream -r typecheck",
 		"*:test": "pnpm --stream -r test",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
 		"apps/*"
 	],
 	"scripts": {
-		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*' --ignore-pattern '~generated-type.ts'",
+		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*'",
 		"precommit": "bun *:package && bun lint && bun *:typecheck && bun *:test",
 		"*:typecheck": "pnpm --stream -r typecheck",
-		"*:test": "pnpm --stream -r test",
+		"*:test": "pnpm -r test",
 		"*:package": "pnpm -r package",
 		"publish": "bun *:package && changeset publish"
 	},

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
 		"apps/*"
 	],
 	"scripts": {
-		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*'",
+		"lint": "eslint ./**/*.{js,ts,cjs} --ignore-pattern 'dist/*' --ignore-pattern '~generated-type.ts'",
 		"precommit": "bun *:package && bun lint && bun *:typecheck && bun *:test",
 		"*:typecheck": "pnpm --stream -r typecheck",
-		"*:test": "pnpm -r test",
+		"*:test": "pnpm --stream -r test",
 		"*:package": "pnpm -r package",
 		"publish": "bun *:package && changeset publish"
 	},

--- a/packages/kit/.gitignore
+++ b/packages/kit/.gitignore
@@ -1,1 +1,1 @@
-/tests/~routes/generated-type.ts
+/tests/~routes/~generated-type.ts

--- a/packages/kit/tests/api-type.test.ts
+++ b/packages/kit/tests/api-type.test.ts
@@ -2,7 +2,7 @@ import { createAPI } from '$/api'
 import { test } from 'bun:test'
 
 // * Note: will be generated on `packages/kit#   bun test`
-import { GeneratedAPI } from './~routes/generated-type'
+import { GeneratedAPI } from './~routes/~generated-type'
 
 test.skip('API types', async () => {
 

--- a/packages/kit/tests/generated-type.test.ts
+++ b/packages/kit/tests/generated-type.test.ts
@@ -7,7 +7,7 @@ test('Generated Type', async () => {
 		resolve(import.meta.path, '../~routes')
 	)
 	await Bun.write(
-		resolve(import.meta.path, '../~routes', 'generated-type.ts'),
+		resolve(import.meta.path, '../~routes', '~generated-type.ts'),
 		type.replace('@apie/kit', '$')
 	)
 })

--- a/packages/kit/tests/generated-type.test.ts
+++ b/packages/kit/tests/generated-type.test.ts
@@ -6,7 +6,7 @@ test('Generated Type', async () => {
 	const type = await createGeneratedType(
 		resolve(import.meta.path, '../~routes')
 	)
-	Bun.write(
+	await Bun.write(
 		resolve(import.meta.path, '../~routes', 'generated-type.ts'),
 		type.replace('@apie/kit', '$')
 	)

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -14,5 +14,6 @@
 			"$types": ["./src/types"],
 			"$types/*": ["./src/types/*"]
 		}
-	}
+	},
+	"exclude": ["./tests/~routes/~generated-type.ts"]
 }

--- a/packages/pipe/src/exit.ts
+++ b/packages/pipe/src/exit.ts
@@ -1,0 +1,19 @@
+const exitSymbol: unique symbol = Symbol('Exit')
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Exit<T = any> = {
+	value: T,
+	[exitSymbol]: true
+}
+
+export function isExit(value: unknown): value is Exit {
+	return value !== null && typeof value === 'object' && value[exitSymbol] === true
+}
+
+export function exit<T>(value?: T) {
+	return {
+		value,
+		[exitSymbol]: true
+	} as Exit<T>
+}
+

--- a/packages/pipe/src/index.ts
+++ b/packages/pipe/src/index.ts
@@ -1,6 +1,7 @@
 import { createEventPipe } from './pipe'
 
 export { createEventPipe } from './pipe'
+export { exit } from './exit'
 export { saveResult } from './save-result'
 export type {
 	Pipeline,

--- a/packages/pipe/src/pipe.ts
+++ b/packages/pipe/src/pipe.ts
@@ -3,6 +3,7 @@ import { type APIResponse } from '@apie/responses/types'
 import { isResponse } from '@apie/responses'
 import { ArbitraryType } from './types/helper'
 import { Pipe, PipeFn } from './types/pipe'
+import { isExit } from './exit'
 
 interface Options<T extends UnknownRecord> {
 	/** Functions to run before every pipeline */
@@ -90,7 +91,7 @@ export function createEventPipe<T extends UnknownRecord = {}>(
 						continue
 					}
 
-					if (isResponse(param)) {
+					if (isResponse(param) || isExit(param)) {
 						previousResult = param
 						break
 					}
@@ -104,6 +105,13 @@ export function createEventPipe<T extends UnknownRecord = {}>(
 						}
 					} catch (error) {
 						return errored(event, error)
+					}
+
+					if (isExit(previousResult)) {
+						previousResult = previousResult.value
+						const result = after(event, previousResult)
+						if (result !== undefined) return result
+						return previousResult
 					}
 
 					if (isResponse(previousResult)) {

--- a/packages/pipe/src/types/helper.ts
+++ b/packages/pipe/src/types/helper.ts
@@ -3,6 +3,7 @@
 import { Nil, UnknownRecord } from '@apie/utility/types'
 import { NestedPipeFn, PipeFn } from './pipe'
 import { APIResponse } from '@apie/responses'
+import { Exit } from '$/exit'
 
 export type ArbitraryType =
 	| string | number | bigint | boolean | symbol
@@ -47,15 +48,23 @@ export type PipeOrValue<
 	[Nil] extends [P]
 	? (
 		R extends PipeFn<infer _, infer _, infer TReturn>
-		? Exclude<NestedPipeInference<TReturn>, APIResponse>
+		? Exclude<NestedPipeInference<TReturn>, APIResponse | Exit>
 		: R extends PipeFn<any, any, infer TReturn>
-		? Exclude<NestedPipeInference<TReturn>, APIResponse>
-		: Exclude<R, APIResponse>
+		? Exclude<NestedPipeInference<TReturn>, APIResponse | Exit>
+		: Exclude<R, APIResponse | Exit>
 	)
 	: (
 		P extends PipeFn<infer _, infer _, infer TReturn>
-		? Exclude<NestedPipeInference<TReturn>, APIResponse>
+		? Exclude<NestedPipeInference<TReturn>, APIResponse | Exit>
 		: P extends PipeFn<any, any, infer TReturn>
-		? Exclude<NestedPipeInference<TReturn>, APIResponse>
+		? Exclude<NestedPipeInference<TReturn>, APIResponse | Exit>
 		: never
 	)
+
+export type ExitValue<P extends PipeFn | Nil> =
+	P extends PipeFn<infer _, infer _, infer R>
+	? (R extends Exit<infer K> ? K : never)
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	: P extends PipeFn<any, any, infer R>
+	? (R extends Exit<infer K> ? K : never)
+	: never

--- a/packages/pipe/src/types/pipe.ts
+++ b/packages/pipe/src/types/pipe.ts
@@ -1,5 +1,5 @@
 import type { MaybePromise, UnknownRecord, Nil, IsUnknownOrNever, FilterNil } from '@apie/utility/types'
-import { ArbitraryType, ParamReturnResponse, PipeInput, PipeOrValue } from './helper'
+import { ArbitraryType, ExitValue, ParamReturnResponse, PipeInput, PipeOrValue } from './helper'
 import { pipe } from '$/pipe'
 import { Input } from './utility'
 import { APIResponse } from '@apie/responses'
@@ -47,16 +47,20 @@ type PipeResult<
 > =
 	(
 		IsUnknownOrNever<Input> extends true ? (
-			Pipeline<(event: T) => Promise<PipeOrValue<Pn, Rn> | ParamReturnResponse<Pall>>>
+			Pipeline<(event: T) => Promise<
+				| PipeOrValue<Pn, Rn>
+				| ParamReturnResponse<Pall>
+				| ExitValue<Pall>
+			>>
 		) : (
 			undefined extends Input ? (
 				Pipeline<
 					(event: T, input?: Input | void) =>
-						Promise<PipeOrValue<Pn, Rn> | ParamReturnResponse<Pall>>
+						Promise<PipeOrValue<Pn, Rn> | ParamReturnResponse<Pall | ExitValue<Pall>>>
 				>
 			) : Pipeline<
 				(event: T, input: Input) => 
-					Promise<PipeOrValue<Pn, Rn> | ParamReturnResponse<Pall>>
+					Promise<PipeOrValue<Pn, Rn> | ParamReturnResponse<Pall> | ExitValue<Pall>>
 			>
 		)
 	)

--- a/packages/pipe/tests/pipe.test.ts
+++ b/packages/pipe/tests/pipe.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { Pipeline, createEventPipe } from '$'
+import { Pipeline, createEventPipe, exit } from '$'
 import { BadRequest, OK } from '@apie/responses'
 import { getBody, isResponse } from '@apie/responses'
 import * as R from '@apie/responses/types'
@@ -99,4 +99,31 @@ test('Pipe and correct no response', async () => {
 
 	expect(result).not.toBeInstanceOf(Response)
 	expect(result).toEqual({ v: 123, d: { c: date } })
+})
+
+test('Pipe exits early with exit()', async () => {
+	const pipeline = pipe(
+		() => {
+			return 1234 as const
+		},
+		(_, v) => {
+			return exit(v)
+		},
+		() => {
+			return OK()
+		},
+		(e, v) => {
+			return 'Mhm.' as const
+		},
+	)
+
+	let result = await pipeline({ yas: 'true' })
+	expect(result).toBe(1234)
+
+	result = 1234
+	result = OK()
+	result = 'Mhm.'
+
+	// @ts-expect-error 0 is not assignable
+	result = 0
 })


### PR DESCRIPTION
```ts
import { exit } from '@apie/pipe'
import { OK } from '@apie/responses'
import pipe from '$pipe'

const pipeline = pipe(
    (e) => {
        if(e.loaded == false) {
            return exit()
        }
    },
    () => {
        // Will never un if e.loaded is `false`, because the
        // previous pipefn exits the pipe early.

        return OK({ message: 'It is loaded!' })
    }
)

```